### PR TITLE
fix: leftover idp issuer for name qualifier check

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build": "tsc",
     "prepare": "run-s build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "eslint \"{src,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,test}/**/*.ts\" --fix",
+    "test": "bash ./test.sh"
   },
   "dependencies": {
     "@node-saml/node-saml": "^4.0.0",

--- a/src/response.ts
+++ b/src/response.ts
@@ -153,7 +153,7 @@ export class SpidResponse extends XML.XML {
     );
     assert.strictEqual(
       data.subject.nameIdQualifier,
-      saml.idpIssuer,
+      idpIssuer,
       `Invalid NameQualifier "${data.subject.nameIdQualifier}"`,
     );
     // SubjectConfirmation


### PR DESCRIPTION
address possibile oversight from this pr (https://github.com/random42/passport-spid/pull/6)