### PR TITLE
fix issue #10 pass RelayState down to additionalParams

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -124,9 +124,7 @@ export class SpidStrategy extends MultiSamlStrategy {
       {},
       saml,
       {
-        additionalParams: {
-          RelayState: 'RelayState',
-        },
+        additionalParams: saml.additionalParams ?? { RelayState: 'RelayState' },
         authnContext: [SPID_LEVELS[config.spid.authnContext]],
         forceAuthn: FORCE_AUTHN_LEVELS.includes(authnContext),
         passReqToCallback: config.passReqToCallback,


### PR DESCRIPTION
fix issue #10.
The main idea is to enable the ability for the user to pass `RelayState` when building the strategy:
```javascript
// configuration code ...
    saml: {
      authnRequestBinding: 'HTTP-POST', // or HTTP-Redirect
      attributeConsumingServiceIndex: '0', // index of 'acs' array
      signatureAlgorithm: 'sha256',
      digestAlgorithm: 'sha256',
      callbackUrl: spCallbackUrl,
      logoutCallbackUrl: spLogoutCallbackUrl,
      racComparison: 'minimum',
      privateKey,
      audience: sp,
      additionalParams: { // pass relaystate to additionalParams
        RelayState: 'send test relay state'
      }
    },
// configuration code ...
```

and then access it via:
```javascript
console.log(req.body.RelayState); 
// OUTPUT:
// send test relay state
```

if no RelayState is provided, the default is used.
I ran the tests, all checks pass,
thank you.